### PR TITLE
support timeout when Connect.

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -144,6 +144,32 @@ func TestTLSNormal(t *testing.T) {
 	}
 }
 
+func TestConnWithTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	addr := "192.168.100.200:8888"
+	client := newTestIOSession(t)
+	defer client.Close()
+
+	err := client.Connect(addr, time.Millisecond*200)
+	assert.Equal(t, true, err.(net.Error).Timeout())
+}
+
+func TestTLSConnWithTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	addr := "192.168.100.200:8888"
+	client := newTestIOSession(t,
+		WithSessionTLSFromCertAndKeys(
+			"./etc/client-cert.pem",
+			"./etc/client-key.pem",
+			"./etc/ca.pem",
+			true),
+	)
+	err := client.Connect(addr, time.Millisecond*200)
+	assert.Equal(t, true, err.(net.Error).Timeout())
+}
+
 func TestReadWithTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Use net.DialTimeout method instead net.Dial and pass the timeout parameter to support timeout when connect.

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
